### PR TITLE
Updated base AMI to RHEL 7.7 and latest Hashicorp versions

### DIFF
--- a/consul/consul-aws.json
+++ b/consul/consul-aws.json
@@ -14,7 +14,7 @@
   },
   "builders": [
     {
-      "name": "amazon-ebs-rhel-7.3-systemd",
+      "name": "amazon-ebs-rhel-7.7-systemd",
       "type": "amazon-ebs",
       "access_key": "{{ user `aws_access_key_id` }}",
       "secret_key": "{{ user `aws_secret_access_key` }}",
@@ -27,7 +27,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "RHEL-7.3_HVM-20170424-x86_64-1-Hourly2-GP2",
+          "name": "RHEL-7.7_HVM_GA-20190723-x86_64-1-Hourly2-GP2",
           "root-device-type": "ebs"
         },
         "owners": ["309956199498"],
@@ -36,10 +36,10 @@
       "ssh_username": "ec2-user",
       "ssh_timeout": "5m",
       "ami_virtualization_type": "hvm",
-      "ami_name": "consul-image_{{ user `release_version` }}_consul_{{ user `consul_version` }}_rhel_7.3",
+      "ami_name": "consul-image_{{ user `release_version` }}_consul_{{ user `consul_version` }}_rhel_7.7",
       "ami_description": "HashiCorp Consul Image {{ user `release_version` }}",
       "tags": {
-        "Name": "Consul RHEL 7.3 Image {{ user `release_version` }}: Consul v{{ user `consul_version` }}",
+        "Name": "Consul RHEL 7.7 Image {{ user `release_version` }}: Consul v{{ user `consul_version` }}",
         "System": "Consul",
         "Product": "Consul",
         "Built-By": "{{ user `vcs_name` }}",
@@ -48,7 +48,7 @@
         "Vault-Version": "nil",
         "Nomad-Version": "nil",
         "OS": "rhel",
-        "OS-Version": "7.3"
+        "OS-Version": "7.7"
       }
     },
     {
@@ -104,7 +104,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/base-aws.sh"
       ]
@@ -135,14 +135,14 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/consul/scripts/install-consul-systemd.sh"
       ]
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "cd /tmp/shared/scripts && bash /tmp/shared/scripts/setup-testing.sh",
         "cd /tmp && rake consul:spec"
@@ -150,7 +150,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/cleanup-aws.sh"
       ]

--- a/hashistack/hashistack-aws.json
+++ b/hashistack/hashistack-aws.json
@@ -28,7 +28,7 @@
   },
   "builders": [
     {
-      "name": "amazon-ebs-rhel-7.3-systemd",
+      "name": "amazon-ebs-rhel-7.7-systemd",
       "type": "amazon-ebs",
       "access_key": "{{ user `aws_access_key_id` }}",
       "secret_key": "{{ user `aws_secret_access_key` }}",
@@ -41,7 +41,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "*RHEL-7.3_HVM_GA-*",
+          "name": "RHEL-7.7_HVM_GA-20190723-x86_64-1-Hourly2-GP2",
           "root-device-type": "ebs"
         },
         "owners": ["309956199498"],
@@ -50,10 +50,10 @@
       "ssh_username": "ec2-user",
       "ssh_timeout": "5m",
       "ami_virtualization_type": "hvm",
-      "ami_name": "hashistack-image_{{ user `release_version` }}_nomad_{{ user `nomad_version` }}_vault_{{ user `vault_version` }}_consul_{{ user `consul_version` }}_rhel_7.3",
+      "ami_name": "hashistack-image_{{ user `release_version` }}_nomad_{{ user `nomad_version` }}_vault_{{ user `vault_version` }}_consul_{{ user `consul_version` }}_rhel_7.7",
       "ami_description": "HashiCorp HashiStack Image {{ user `release_version` }}",
       "tags": {
-        "Name": "HashiStack RHEL 7.3 Image {{ user `release_version` }}: Consul v{{ user `consul_version` }} Vault v{{ user `vault_version` }} Nomad v{{ user `nomad_version` }}",
+        "Name": "HashiStack RHEL 7.7 Image {{ user `release_version` }}: Consul v{{ user `consul_version` }} Vault v{{ user `vault_version` }} Nomad v{{ user `nomad_version` }}",
         "System": "HashiStack",
         "Product": "HashiStack",
         "Built-By": "{{ user `vcs_name` }}",
@@ -62,7 +62,7 @@
         "Vault-Version": "{{ user `vault_version` }}",
         "Nomad-Version": "{{ user `nomad_version` }}",
         "OS": "rhel",
-        "OS-Version": "7.3"
+        "OS-Version": "7.7"
       }
     },
     {
@@ -118,7 +118,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/base-aws.sh"
       ]
@@ -155,7 +155,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/consul/scripts/install-consul-systemd.sh"
       ]
@@ -186,7 +186,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/vault/scripts/install-vault-systemd.sh"
       ]
@@ -205,20 +205,24 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/nomad/scripts/install-nomad-systemd.sh"
       ]
     },
      {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/nomad/scripts/install-docker.sh"
       ]
     },
     {
       "type": "shell",
+      "environment_vars": [
+        "AWS_ACCESS_KEY_ID={{ user `aws_access_key_id` }}",
+        "AWS_SECRET_ACCESS_KEY={{ user `aws_secret_access_key` }}"
+      ],
       "inline": [
         "bash /tmp/nomad/scripts/install-java.sh"
       ]
@@ -250,7 +254,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "cd /tmp/shared/scripts && bash setup-testing.sh",
         "cd /tmp/hashistack && rake spec"
@@ -258,7 +262,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/cleanup-aws.sh"
       ]

--- a/hashistack/hashistack-azure.json
+++ b/hashistack/hashistack-azure.json
@@ -20,7 +20,7 @@
   },
     "builders": [
   {
-      "name": "azure-managed-image-RHEL-7.3-systemd",
+      "name": "azure-managed-image-RHEL-7.7-systemd",
       "type": "azure-arm",
       "client_id": "{{ user `azure_client_id` }}",
       "client_secret": "{{ user `azure_client_secret` }}",
@@ -29,10 +29,10 @@
       "location": "{{ user `azure_location` }}",
       "image_publisher": "RedHat",
       "image_offer": "RHEL",
-      "image_sku": "7.3",
+      "image_sku": "7.7",
       "os_type": "Linux",
       "ssh_username": "packer",
-      "managed_image_name": "{{ user `environment` }}-hashistack-server-{{ user `distribution` }}-RHEL_7.3-{{timestamp}}",
+      "managed_image_name": "{{ user `environment` }}-hashistack-server-{{ user `distribution` }}-rhel_7.7-{{timestamp}}",
       "azure_tags": {
           "Name": "HashiStack Server",
           "System": "HashiStack",
@@ -40,7 +40,7 @@
           "Environment": "{{ user `environment` }}",
           "Built-By": "{{ user `vcs_name` }}",
           "OS": "RHEL",
-          "OS-Version": "7.3",
+          "OS-Version": "7.7",
           "Consul-Version": "{{ user `consul_version` }}",
           "Nomad-Version": "{{ user `nomad_version` }}",
           "Vault-Version": "{{ user `vault_version` }}"
@@ -103,7 +103,7 @@
     },
     {
       "type": "shell",
-      "only": ["azure-managed-image-RHEL-7.3-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
+      "only": ["azure-managed-image-RHEL-7.7-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/base-aws.sh"
       ]
@@ -132,7 +132,7 @@
     },
     {
       "type": "shell",
-      "only": ["azure-managed-image-RHEL-7.3-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
+      "only": ["azure-managed-image-RHEL-7.7-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/consul/scripts/install-consul-systemd.sh"
       ]
@@ -149,7 +149,7 @@
     },
     {
       "type": "shell",
-      "only": ["azure-managed-image-RHEL-7.3-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
+      "only": ["azure-managed-image-RHEL-7.7-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/nomad/scripts/install-nomad-systemd.sh"
       ]
@@ -191,7 +191,7 @@
     },
     {
       "type": "shell",
-      "only": ["azure-managed-image-RHEL-7.3-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
+      "only": ["azure-managed-image-RHEL-7.7-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/vault/scripts/install-vault-systemd.sh"
       ]
@@ -204,7 +204,7 @@
     },
     {
       "type": "shell",
-      "only": ["azure-managed-image-RHEL-7.3-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
+      "only": ["azure-managed-image-RHEL-7.7-systemd", "azure-managed-image-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/cleanup-aws.sh"
       ]

--- a/hashistack/hashistack-gcp.json
+++ b/hashistack/hashistack-gcp.json
@@ -39,7 +39,7 @@
       }
     },
     {
-      "name": "gcp-rhel-7.3-systemd",
+      "name": "gcp-rhel-7.7-systemd",
       "image_description": "Hashicorp HashiStack Server",
       "image_name": "{{ (user `environment`) | clean_image_name }}-hashistack-server-{{ (user `distribution`) | clean_image_name }}-rhel-7-3",
       "type": "googlecompute",
@@ -116,7 +116,7 @@
       "type": "shell",
       "only": [
         "gcp-ubuntu-16.04-systemd",
-        "gcp-rhel-7.3-systemd"
+        "gcp-rhel-7.7-systemd"
       ],
       "inline": [
         "bash /tmp/consul/scripts/install-consul-systemd.sh"
@@ -136,7 +136,7 @@
       "type": "shell",
       "only": [
         "gcp-ubuntu-16.04-systemd",
-        "gcp-rhel-7.3-systemd"
+        "gcp-rhel-7.7-systemd"
       ],
       "inline": [
         "bash /tmp/nomad/scripts/install-nomad-systemd.sh"
@@ -183,7 +183,7 @@
       "type": "shell",
       "only": [
         "gcp-ubuntu-16.04-systemd",
-        "gcp-rhel-7.3-systemd"
+        "gcp-rhel-7.7-systemd"
       ],
       "inline": [
         "bash /tmp/vault/scripts/install-vault-systemd.sh"
@@ -213,7 +213,7 @@
     },
     {
       "type": "googlecompute-export",
-      "only": ["gcp-rhel-7.3-systemd"],
+      "only": ["gcp-rhel-7.7-systemd"],
       "paths": [
         "gs://hc-se-image-store/{{ user `environment` }}/consul-{{ user `consul_version`}}-nomad-{{ user `nomad_version`}}-vault-{{ user `vault_version`}}/hashistack-server-rhel-7-3.tar.gz"
       ],

--- a/nomad/nomad-aws.json
+++ b/nomad/nomad-aws.json
@@ -19,7 +19,7 @@
   },
   "builders": [
     {
-      "name": "amazon-ebs-rhel-7.3-systemd",
+      "name": "amazon-ebs-rhel-7.7-systemd",
       "type": "amazon-ebs",
       "access_key": "{{ user `aws_access_key_id` }}",
       "secret_key": "{{ user `aws_secret_access_key` }}",
@@ -32,7 +32,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "*RHEL-7.3_HVM_GA-*",
+          "name": "RHEL-7.7_HVM_GA-20190723-x86_64-1-Hourly2-GP2",
           "root-device-type": "ebs"
         },
         "owners": ["309956199498"],
@@ -41,10 +41,10 @@
       "ssh_username": "ec2-user",
       "ssh_timeout": "5m",
       "ami_virtualization_type": "hvm",
-      "ami_name": "nomad-image_{{ user `release_version` }}_nomad_{{ user `nomad_version` }}_consul_{{ user `consul_version` }}_rhel_7.3",
+      "ami_name": "nomad-image_{{ user `release_version` }}_nomad_{{ user `nomad_version` }}_consul_{{ user `consul_version` }}_rhel_7.7",
       "ami_description": "HashiCorp Nomad Image {{ user `release_version` }}",
       "tags": {
-        "Name": "Nomad RHEL 7.3 Image {{ user `release_version` }}: Nomad v{{ user `nomad_version` }} Consul v{{ user `consul_version` }}",
+        "Name": "Nomad RHEL 7.7 Image {{ user `release_version` }}: Nomad v{{ user `nomad_version` }} Consul v{{ user `consul_version` }}",
         "System": "Nomad",
         "Product": "Nomad",
         "Built-By": "{{ user `vcs_name` }}",
@@ -53,7 +53,7 @@
         "Vault-Version": "nil",
         "Nomad-Version": "{{ user `nomad_version` }}",
         "OS": "rhel",
-        "OS-Version": "7.3"
+        "OS-Version": "7.7"
       }
     },
     {
@@ -109,7 +109,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/base-aws.sh"
       ]
@@ -140,7 +140,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/consul/scripts/install-consul-systemd.sh"
       ]
@@ -159,14 +159,14 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/nomad/scripts/install-nomad-systemd.sh"
       ]
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/nomad/scripts/install-docker.sh"
       ]
@@ -179,7 +179,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "cd /tmp/shared/scripts && bash /tmp/shared/scripts/setup-testing.sh",
         "cd /tmp && rake nomad:spec"
@@ -187,7 +187,7 @@
     },
      {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/cleanup-aws.sh"
       ]

--- a/nomad/scripts/install-java.sh
+++ b/nomad/scripts/install-java.sh
@@ -12,15 +12,17 @@ download_jdk() {
     --retry 5 \
     --retry-delay 0 \
     --retry-max-time 60"
-  readonly URL="http://www.oracle.com"
-  readonly JDK_DOWNLOAD_URL1="${URL}/technetwork/java/javase/downloads/index.html"
-  readonly JDK_DOWNLOAD_URL2=$(${curl_cmd} ${JDK_DOWNLOAD_URL1} | egrep -o "\/technetwork\/java/\javase\/downloads\/jdk${JDK_VERSION}-downloads-.+?\.html" | head -1 | cut -d '"' -f 1)
-  [[ -z "${JDK_DOWNLOAD_URL2}" ]] && echo "Could not get jdk download url - ${JDK_DOWNLOAD_URL1}" && exit 1
-  readonly JDK_DOWNLOAD_URL3="${URL}${JDK_DOWNLOAD_URL2}"
-  readonly JDK_DOWNLOAD_URL4=$(${curl_cmd} ${JDK_DOWNLOAD_URL3} | egrep -o "http\:\/\/download.oracle\.com\/otn-pub\/java\/jdk\/[7-8]u[0-9]+\-(.*)+\/jdk-[7-8]u[0-9]+(.*)linux-x64.${EXT}" | tail -1)
-  for DL_URL in "${JDK_DOWNLOAD_URL4[@]}"; do
-    wget --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -N ${DL_URL}
-  done
+  # readonly URL="https://www.oracle.com"
+  # readonly JDK_DOWNLOAD_URL1="${URL}/technetwork/java/javase/downloads/index.html"
+  # readonly JDK_DOWNLOAD_URL2=$(${curl_cmd} ${JDK_DOWNLOAD_URL1} | grep -E -o "\/technetwork\/java/\javase\/downloads\/jdk${JDK_VERSION}-downloads-.+?\.html" | head -1 | cut -d '"' -f 1)
+  # [[ -z "${JDK_DOWNLOAD_URL2}" ]] && echo "Could not get jdk download url - ${JDK_DOWNLOAD_URL1}" && exit 1
+  # readonly JDK_DOWNLOAD_URL3="${URL}${JDK_DOWNLOAD_URL2}"
+  # readonly JDK_DOWNLOAD_URL4=$(${curl_cmd} "${JDK_DOWNLOAD_URL3}" | grep -E -o "https\:\/\/download\.oracle\.com\/otn\/java\/.*\/jdk-${JDK_VERSION}u[0-9]+(.*)linux-x64.${EXT}" | tail -1)
+  # for DL_URL in "${JDK_DOWNLOAD_URL4[@]}"; do
+  DL_URL='https://javadl.oracle.com/webapps/download/AutoDL?BundleId=239847_230deb18db3e4014bb8e3e8324f81b43'
+  wget --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -N "${DL_URL}"
+  mv 'AutoDL?BundleId=239847_230deb18db3e4014bb8e3e8324f81b43' jre-8u221-linux-x64.rpm
+  #  done
 }
 
 echo "Running"
@@ -33,11 +35,13 @@ APT_GET=$(which apt-get 2>/dev/null)
 
 if [[ ! -z ${YUM} ]]; then
   echo "RHEL/CentOS system detected"
-  download_jdk 8 rpm
+  aws s3 cp s3://infosec-vault/jdk-8u221-linux-x64.rpm .
+  # download_jdk 8 rpm
   sudo rpm -Uvh jdk-*-linux-x64.rpm
 elif [[ ! -z ${APT_GET} ]]; then
   echo "Debian/Ubuntu system detected"
-  download_jdk 8 tar.gz
+  # download_jdk 8 tar.gz
+  aws s3 cp s3://infosec-vault/jdk-8u221-linux-x64.tar.gz .
   sudo mkdir -p /opt/jdk
   sudo tar xf jdk-*-linux-x64.tar.gz -C /opt/jdk
   JDK_VERSION="$(ls /opt/jdk/)"

--- a/vault/vault-aws.json
+++ b/vault/vault-aws.json
@@ -20,7 +20,7 @@
   },
   "builders": [
     {
-      "name": "amazon-ebs-rhel-7.3-systemd",
+      "name": "amazon-ebs-rhel-7.7-systemd",
       "type": "amazon-ebs",
       "access_key": "{{ user `aws_access_key_id` }}",
       "secret_key": "{{ user `aws_secret_access_key` }}",
@@ -33,7 +33,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "RHEL-7.3_HVM-20170424-x86_64-1-Hourly2-GP2",
+          "name": "RHEL-7.7_HVM_GA-20190723-x86_64-1-Hourly2-GP2",
           "root-device-type": "ebs"
         },
         "owners": ["309956199498"],
@@ -42,10 +42,10 @@
       "ssh_username": "ec2-user",
       "ssh_timeout": "5m",
       "ami_virtualization_type": "hvm",
-      "ami_name": "vault-image_{{ user `release_version` }}_vault_{{ user `vault_version` }}_consul_{{ user `consul_version` }}_rhel_7.3",
+      "ami_name": "vault-image_{{ user `release_version` }}_vault_{{ user `vault_version` }}_consul_{{ user `consul_version` }}_rhel_7.7",
       "ami_description": "HashiCorp Vault Image {{ user `release_version` }}",
       "tags": {
-        "Name": "Vault RHEL 7.3 Image {{ user `release_version` }}: Vault v{{ user `vault_version` }} Consul v{{ user `consul_version` }}",
+        "Name": "Vault RHEL 7.7 Image {{ user `release_version` }}: Vault v{{ user `vault_version` }} Consul v{{ user `consul_version` }}",
         "System": "Vault",
         "Product": "Vault",
         "Built-By": "{{ user `vcs_name` }}",
@@ -54,7 +54,7 @@
         "Vault-Version": "{{ user `vault_version` }}",
         "Nomad-Version": "nil",
         "OS": "rhel",
-        "OS-Version": "7.3"
+        "OS-Version": "7.7"
       }
     },
     {
@@ -110,7 +110,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/base-aws.sh"
       ]
@@ -141,7 +141,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/consul/scripts/install-consul-systemd.sh"
       ]
@@ -172,14 +172,14 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/vault/scripts/install-vault-systemd.sh"
       ]
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "cd /tmp/shared/scripts && bash /tmp/shared/scripts/setup-testing.sh",
         "cd /tmp && rake vault:spec"
@@ -187,7 +187,7 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.7-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
         "bash /tmp/shared/scripts/cleanup-aws.sh"
       ]

--- a/versions.sh
+++ b/versions.sh
@@ -13,16 +13,16 @@ export TERRAFORM_VERSION="0.11.14"
 # Release candidate: X.Y.Z-rcX (e.g. 0.1.0-rc1)
 # Beta release: X.Y.Z-betaX (e.g. 0.1.0-beta1)
 # Development branch: X.Y.Z-f-branch (e.g. 0.1.0-f-branch)
-export RELEASE_VERSION="1.0.0"
+export RELEASE_VERSION="1.0.1"
 
 # X.Y.Z or X.Y.Z-ent for Enterprise binary (e.g. 1.0.6 or 1.0.6-ent)
-export CONSUL_VERSION="1.5.2"
+export CONSUL_VERSION="1.6.0"
 
 # X.Y.Z or X.Y.Z-ent for Enterprise binary (e.g. 0.10.0 or 0.10.0-ent)
-export VAULT_VERSION="1.1.3"
+export VAULT_VERSION="1.2.2"
 
 # X.Y.Z or X.Y.Z-ent for Enterprise binary (e.g. 0.8.0 or 0.8.0-ent)
-export NOMAD_VERSION="0.9.3"
+export NOMAD_VERSION="0.9.5"
 
 # The below are aggregate lists of product versions to be published. Any
 # time a product version above is updated, that new version _must_ be
@@ -38,10 +38,10 @@ export NOMAD_VERSION="0.9.3"
 # To make a `release_versions` images public, set the version map value to
 # `true` or `false`. Enterprise images will _not_ be set to public even if
 # `true` is set.
-export RELEASE_VERSIONS='release_versions=[{"0.1.0"=true},{"0.1.1"=false},{"1.0.0"=false},]'
-export CONSUL_VERSIONS='consul_versions=["1.2.3","1.2.3-ent","1.5.2",]'
-export VAULT_VERSIONS='vault_versions=["0.11.3","0.11.3-ent","1.1.3",]'
-export NOMAD_VERSIONS='nomad_versions=["0.8.6","0.8.6-ent","0.9.3",]'
+export RELEASE_VERSIONS='release_versions=[{"0.1.0"=true},{"0.1.1"=false},{"1.0.0"=false},{"1.0.1"=false},]'
+export CONSUL_VERSIONS='consul_versions=["1.2.3","1.2.3-ent","1.5.2","1.6.0"]'
+export VAULT_VERSIONS='vault_versions=["0.11.3","0.11.3-ent","1.1.3","1.2.2"]'
+export NOMAD_VERSIONS='nomad_versions=["0.8.6","0.8.6-ent","0.9.3","0.9.5"]'
 
 # Force build or run on feature branch
 export RUN_BUILD=false


### PR DESCRIPTION
Updated to: 
1. RHEL `7.7`
1. Vault `1.2.2`
1. Consul `1.6.0`
1. Nomad `0.9.5`
